### PR TITLE
combineModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export default { actions, reducers, selectors };
 
 `reducers/drinks.js`
 ```js
-import { combineModules } from 'modular-redux-thunk';
+import { combineModules, settableValue } from 'modular-redux-thunk';
 const actions = {};
 const reducers = {};
 const selectors = {};
@@ -117,24 +117,8 @@ const favorite = {
 	}
 }
 
-const SET_DRINKS_FOR_SALE = `${ACTION_PREPEND}/SET_DRINKS_FOR_SALE`;
-const drinksForSale = {
-	reducer: (state = [], action) => {
-	  switch(action.type) {
-	    case SET_DRINKS_FOR_SALE: return action.drinks;
-	    default: return state;
-	  };
-	},
-	actions: {
-		setDrinksForSale: (drinks) => ({
-			type: SET_DRINKS_FOR_SALE,
-	    drinks
-		})
-	},
-	selectors: {
-		getDrinksForSale: (drinksForSaleState) => drinksForSaleState
-	}
-}
+// Or even use a module creator function to automate this common pattern
+const drinksForSale = settableValue([], 'getDrinksForSale', 'setDrinksForSale');
 
 export default combineModules({
 	favorite,
@@ -231,7 +215,7 @@ A module object consists of:
 
 ## `createStore(modules, [globalDefinitions], [reduxConfig])`
 
-Create's a Redux store that combines your reducers into a single and complete state tree.
+Creates a Redux store that combines your reducers into a single and complete state tree.
 
 ### Arguments
 
@@ -246,9 +230,20 @@ Create's a Redux store that combines your reducers into a single and complete st
 	- `[middleware]` (*array*):  Any custom middleware to be added to the store. [redux-thunk](https://github.com/gaearon/redux-thunk) is automatically included as a middleware for your convenience.
 	- `[enhancers]` (*array*):  Any custom enhancers to be added to the store, such as [redux-freeze](https://github.com/buunguyen/redux-freeze). When not in production, [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) is automatically added for your convenience.
 
-## combineModules(modules)
+## `combineModules(modules)`
 
 Takes a map of Module objects and returns a single Module object.
+
+## `settableValue(initialValue, selectorName, actionName, [actionType])`
+
+Creates a module that controls a single value and responds to a single "set" action, as is quite common in Redux.
+
+### Arguments
+
+1. `initialValue` - The initial value of the module
+2. `selectorName` - The name of the module's single selector - usually something like `getMyValue`
+3. `actionName` - The name of the module's single action creator - usually something like `setMyValue`
+4. `actionType` - Optional. The action's type constant - usually something like `SET_MY_VALUE`. If not set, it will default to `actionName`.
 
 # TODO
 - Finish pending tests

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Creates a module that controls a single value and responds to a single "set" act
 #### Releasing
 ```
 Commit all changes
-npm run build -> test && clean:build && build && test:build
+npm run build # runs "npm test && npm run clean:build && npm run build && npm run test:build"
 npm version "v1.0.0-beta1" -m "Message"
 npm publish
 git push origin HEAD:master --tags

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A [ducks](https://github.com/erikras/ducks-modular-redux)-inspired package to he
 
 
 ### Rules
-- **Each reducer is only aware of it's own state.** Reducer's don't care or know about each other's state.
-- **Only a reducer should be aware of how its state is structured.** You define all actions, reducers, and selectors in each reducer that manipulate and retrieve data from that reducer.
+- **Each module is only aware of it's own state.** Reducer's don't care or know about each other's state.
+- **Only a module should be aware of how its state is structured.** You define all actions, reducers, and selectors in each module that manipulate and retrieve data from that reducer.
 - **You can define global actions and global selectors.** Occasionally, you'll need to dispatch actions or define selectors that use multiple reducers. Global actions have access to all defined actions, and global reducers have access to all defined selectors.
-- **Connected components should not assume to know how the store is structured.** When creating connected components, you should never reference the state directly. Instead, use the selectors you've defined in each reducer, and any global reducers, to return that data.
-- **You should not have to update your connected components when changing your store's structure.** This is a huge bonus. Since all components use *pickActions* and *selectors* (more about that below), you can change your store's structure as much as you'd like. For example, you can move a data node from one reducer to another without affecting your components - as along as you maintain your actions and update your selectors to reflect the latest structure.
+- **Connected components should not assume to know how the store is structured.** When creating connected components, you should never reference the state directly. Instead, use the selectors you've defined in each module, and any global reducers, to return that data.
+- **You should not have to update your connected components when changing your store's structure.** This is a huge bonus. Since all components use *pickActions* and *selectors* (more about that below), you can change your store's structure as much as you'd like. For example, you can move a data node from one module to another without affecting your components - as along as you maintain your actions and update your selectors to reflect the latest structure.
 
 # Installation
 
@@ -20,7 +20,7 @@ A [ducks](https://github.com/erikras/ducks-modular-redux)-inspired package to he
 ```js
 import createStore from 'modular-redux-thunk';
 
-const { store, pickActions, selectors } = createStore(myModularReduxDefinition);
+const { store, pickActions, selectors } = createStore(myModules);
 ```
 
 You can also include custom reducers, middleware, or enhancers. For example, if you install react-router and redux-freeze:
@@ -33,7 +33,7 @@ npm install --save react-router
 import createStore from 'modular-redux-thunk';
 import { routerReducer } from 'react-router-redux';
 
-const { store, pickActions, selectors } = createStore(myModularReduxDefinition, {
+const { store, pickActions, selectors } = createStore(myModules, {
 	reducers: {
 		routing: routerReducer
 	},
@@ -44,9 +44,9 @@ const { store, pickActions, selectors } = createStore(myModularReduxDefinition, 
 # Example
 
 Let's say your app will be storing the following information in the state:
-* A list of chips you sale
+* A list of chips you sell
 * The logged-in-user's favorite chips
-* A list of drinks you sale
+* A list of drinks you sell
 * The logged-in-user's favorite drink
 
 `reducers/chips.js`
@@ -91,42 +91,55 @@ export default { actions, reducers, selectors };
 
 `reducers/drinks.js`
 ```js
+import { combineModules } from 'modular-redux-thunk';
 const actions = {};
 const reducers = {};
 const selectors = {};
 const ACTION_PREPEND = 'my-react-app/drinks';
 
+// You can also define individual modules and combine them
 const SET_FAVORITE_DRINK = `${ACTION_PREPEND}/SET_FAVORITE_DRINK`;
-reducers.favorite = (state = 'unknown', action) => {
-  switch(action.type) {
-    case SET_FAVORITE_DRINK: return action.newFav;
-    default: return state;
-  };
-};
-actions.setFavoriteDrink = (newFav) => {
-  return {
-    type: SET_FAVORITE_DRINK,
-    newFav
-  };
-};
-selectors.getFavoriteDrink = (drinkState) => drinkState.favorite;
+const favorite = {
+	reducer: (state = 'unknown', action) => {
+	  switch(action.type) {
+	    case SET_FAVORITE_DRINK: return action.newFav;
+	    default: return state;
+	  };
+	},
+	actions: {
+		setFavoriteDrink: (newFav) => ({
+	    type: SET_FAVORITE_DRINK,
+	    newFav
+	  })
+	},
+	selectors: {
+		getFavoriteDrink: (favoriteDrinkState) => favoriteDrinkState;
+	}
+}
 
 const SET_DRINKS_FOR_SALE = `${ACTION_PREPEND}/SET_DRINKS_FOR_SALE`;
-reducers.drinksForSale = (state = [], action) => {
-  switch(action.type) {
-    case SET_DRINKS_FOR_SALE: return action.drinks;
-    default: return state;
-  };
-};
-actions.setDrinksForSale = (drinks) => {
-  return {
-    type: SET_DRINKS_FOR_SALE,
-    drinks
-  };
-};
-selectors.getDrinksForSale = (drinksState) => drinksState.drinks;
+const drinksForSale = {
+	reducer: (state = [], action) => {
+	  switch(action.type) {
+	    case SET_DRINKS_FOR_SALE: return action.drinks;
+	    default: return state;
+	  };
+	},
+	actions: {
+		setDrinksForSale: (drinks) => ({
+			type: SET_DRINKS_FOR_SALE,
+	    drinks
+		})
+	},
+	selectors: {
+		getDrinksForSale: (drinksForSaleState) => drinksForSaleState
+	}
+}
 
-export default { actions, reducers, selectors };
+export default combineModules({
+	favorite,
+	drinksForSale
+});
 ```
 
 `reducers/selectors.js`
@@ -158,14 +171,14 @@ import drinks from './drinks.js';
 import * as globalActions from './actions.js';
 import * as globalSelectors from './selectors.js';
 
-const reducers = {chips, drinks};
+const modules = {chips, drinks};
 
 const globals = {
   globalActions: globalActions,
   globalSelectors: globalSelectors
 };
 
-const { store, selectors, pickActions } = createStore(reducers, globals);
+const { store, selectors, pickActions } = createStore(modules, globals);
 export { store, selectors, pickActions };
 ```
 
@@ -206,17 +219,23 @@ ReactDOM.render(
 
 # API Reference
 
-`createStore(modularReduxDefinition, [globalDefinitions], [reduxConfig])`
+## Module
+
+A module object consists of:
+
+- One of the following:
+	- `reducer` - A standard Redux reducer function. Each reducer should be defined in it's simplest form. For example, define reducers that are strings, booleans, numbers, or arrays.
+	- `reducers` - An object of Redux reducer functions. If you choose this option, its value will be run through `Redux.combineReducers`.
+- `actions` (*object*): A map of action creator functions. Each action should return an object with, at the very least, a `type` property.
+- `selectors` (*object*): Selector functions that connected components call to get parts of the state. A selector's first and only argument is the module's current state.
+
+## `createStore(modules, [globalDefinitions], [reduxConfig])`
 
 Create's a Redux store that combines your reducers into a single and complete state tree.
 
 ### Arguments
 
-1. `modularReduxDefinition` (*object*): Defines the global structure of the store. Each key represents the reducer's location in the store, and the value is the reducer object itself. Each reducer object should have three keys:
-	- `reducers` (*object*): Data nodes that respond to actions. Each data node should be defined in it's simplest form. For example, define reducers that are strings, booleans, numbers, or arrays.
-	- `actions` (*object*): Actions that can be performed on the reducers. Actions are how your connected components manipulate the store.
-	- `selectors` (*object*): Selectors that connected components call to get parts of the reducer. Selectors first argument will always be:
-		- `reducerState` (*object*):  The state of the reducer, which is used to return parts of the state.
+1. `modules` (*object*): Defines the global structure of the store. Each key represents the modules's location in the store, and the value is the module object itself. Module objects are described above.
 2. `[globalDefinitions]` (*object*):  Pass in any global actions or selectors. Globals are given access to all reducers. You can pass in the following keys:
 	- `[globalActions]` (*object*):  Actions that can themselves perform actions from any reducer. Global actions differ from reducer actions in that the first argument will always be:
 		- `combinedActions` (*object*):  All combined actions from reducers. This allows you to reference reducer-defined actions.
@@ -227,6 +246,9 @@ Create's a Redux store that combines your reducers into a single and complete st
 	- `[middleware]` (*array*):  Any custom middleware to be added to the store. [redux-thunk](https://github.com/gaearon/redux-thunk) is automatically included as a middleware for your convenience.
 	- `[enhancers]` (*array*):  Any custom enhancers to be added to the store, such as [redux-freeze](https://github.com/buunguyen/redux-freeze). When not in production, [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) is automatically added for your convenience.
 
+## combineModules(modules)
+
+Takes a map of Module objects and returns a single Module object.
 
 # TODO
 - Finish pending tests

--- a/specs/src/consoleErrors.spec.js
+++ b/specs/src/consoleErrors.spec.js
@@ -229,5 +229,26 @@ describe('consoleErrors', function() {
         expect(invalidReducerConfig).to.equal(true);
       });
     });
+
+    itWithConsoleErrorStub('should allow either reducers or reducer', function () {
+      const testConfig = validConfigCopy();
+      delete testConfig.reducers;
+      testConfig.reducer = (state, action) => 'hello';
+
+      const result = consoleErrors.invalidReducerConfig('reDUCerNAMe', testConfig);
+      expect(result).to.equal(false);
+      expectCallCount().to.equal(0);
+    });
+
+    itWithConsoleErrorStub('should fail if reducer is not a function', function () {
+      const testConfig = validConfigCopy();
+      delete testConfig.reducers;
+      testConfig.reducer = 'nope';
+
+      const result = consoleErrors.invalidReducerConfig('reDUCerNAMe', testConfig);
+      expectCallCount().to.equal(1);
+      expect(result).to.equal(true);
+      expectArg().to.contain('reDUCerNAMe').and.contain('reducer').and.contain('function').and.contain('not string');
+    });
   });
 });

--- a/specs/src/moduleCreators.spec.js
+++ b/specs/src/moduleCreators.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { combineModules } from '../../src/modules';
+import { settableValue } from '../../src/moduleCreators';
+
+describe('module creators', function () {
+  describe('settableValue', function () {
+    const { reducer, actions, selectors } = settableValue('INITIAL VALUE', 'getMyValue', 'setMyValue', 'SET_MY_VALUE');
+
+    it('should respect the initial value', function () {
+      expect(reducer(undefined, { type: '__INIT__' })).to.equal('INITIAL VALUE');
+    });
+
+    it('should have a selector', function () {
+      expect(selectors.getMyValue('NEW VALUE')).to.equal('NEW VALUE');
+    });
+
+    it('should have an action creator', function () {
+      expect(
+        reducer('OLD VALUE', actions.setMyValue('NEW VALUE'))
+      ).to.equal('NEW VALUE');
+    });
+  });
+});

--- a/specs/src/modules.spec.js
+++ b/specs/src/modules.spec.js
@@ -103,7 +103,4 @@ describe('modules', function () {
     const combinedModule = combineModules({ testModule });
     expect(combinedModule.reducer(undefined, { type: '__INIT__' })).to.deep.equal({ testModule: 'hello' });
   });
-
-  // it('should have a settableValueModule helper')
-  // it('should support array modules of some sort')
 });

--- a/specs/src/modules.spec.js
+++ b/specs/src/modules.spec.js
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { combineModules } from '../../src/modules';
+
+describe('deeply nested modules', function () {
+  const SET_FAVORITE_CHIPS = 'chips/SET_FAVORITE_CHIPS';
+  const SET_CHIPS_FOR_SALE = 'chips/SET_CHIPS_FOR_SALE';
+
+  const favoriteChips = {
+    reducer: (state = 'unknown', action) => {
+      switch (action.type) {
+        case SET_FAVORITE_CHIPS:
+          return action.newFav;
+        default:
+          return state;
+      }
+    },
+    actions: {
+      setFavoriteChips: (newFav) => ({ type: SET_FAVORITE_CHIPS, newFav })
+    },
+    selectors: {
+      getFavoriteChips: (state) => state
+    }
+  }
+
+  const chipsForSale = {
+    reducer: (state = [], action) => {
+      switch (action.type) {
+        case SET_CHIPS_FOR_SALE:
+          return action.chips
+        default:
+          return state;
+      }
+    },
+    actions: {
+      setChipsForSale: (chips) => ({ type: SET_CHIPS_FOR_SALE, chips })
+    },
+    selectors: {
+      getChipsForSale: (state) => state
+    }
+  };
+
+  it('should combine modules', function () {
+    const singleModule = combineModules({
+      favoriteChips,
+      chipsForSale
+    });
+
+    expect(singleModule.reducer).to.be.a('function');
+    expect(singleModule.reducer(undefined, { type: '__INIT__' })).to.deep.equal({
+      favoriteChips: 'unknown',
+      chipsForSale: [],
+    }, 'should combine reducers');
+
+    expect(singleModule.actions.setFavoriteChips('bbq')).to.deep.equal({
+      type: SET_FAVORITE_CHIPS,
+      newFav: 'bbq'
+    }, 'should combine actions');
+    expect(singleModule.actions.setChipsForSale(['salt & vinegar'])).to.deep.equal({
+      type: SET_CHIPS_FOR_SALE,
+      chips: ['salt & vinegar']
+    }, 'should combine actions');
+
+    const mockState = {
+      favoriteChips: 'bbq',
+      chipsForSale: ['salt & vinegar']
+    };
+    expect(singleModule.selectors.getFavoriteChips(mockState)).to.equal('bbq', 'should combine selectors');
+    expect(singleModule.selectors.getChipsForSale(mockState)).to.deep.equal(['salt & vinegar'], 'should combine selectors');
+  });
+
+  // it('should have a settableValueModule helper')
+  // it('should support array modules of some sort')
+  // it('should support reducers property for compatability with classic module pattern')
+});

--- a/specs/src/modules.spec.js
+++ b/specs/src/modules.spec.js
@@ -1,98 +1,107 @@
 import { expect } from 'chai';
-import { combineModules } from '../../src/modules';
+import { combineModules, reducerToModule } from '../../src/modules';
 
-describe('deeply nested modules', function () {
+describe('modules', function () {
   const SET_FAVORITE_CHIPS = 'chips/SET_FAVORITE_CHIPS';
   const SET_CHIPS_FOR_SALE = 'chips/SET_CHIPS_FOR_SALE';
 
-  it('should combine modules', function () {
-    const favoriteChips = {
-      reducer: (state = 'unknown', action) => {
-        switch (action.type) {
-          case SET_FAVORITE_CHIPS:
-            return action.newFav;
-          default:
-            return state;
+  describe('combineModules', function () {
+    it('should combine modules', function () {
+      const favoriteChips = {
+        reducer: (state = 'unknown', action) => {
+          switch (action.type) {
+            case SET_FAVORITE_CHIPS:
+              return action.newFav;
+            default:
+              return state;
+          }
+        },
+        actions: {
+          setFavoriteChips: (newFav) => ({ type: SET_FAVORITE_CHIPS, newFav })
+        },
+        selectors: {
+          getFavoriteChips: (state) => state
         }
-      },
-      actions: {
-        setFavoriteChips: (newFav) => ({ type: SET_FAVORITE_CHIPS, newFav })
-      },
-      selectors: {
-        getFavoriteChips: (state) => state
       }
-    }
 
-    const chipsForSale = {
-      reducer: (state = [], action) => {
-        switch (action.type) {
-          case SET_CHIPS_FOR_SALE:
-            return action.chips
-          default:
-            return state;
+      const chipsForSale = {
+        reducer: (state = [], action) => {
+          switch (action.type) {
+            case SET_CHIPS_FOR_SALE:
+              return action.chips
+            default:
+              return state;
+          }
+        },
+        actions: {
+          setChipsForSale: (chips) => ({ type: SET_CHIPS_FOR_SALE, chips })
+        },
+        selectors: {
+          getChipsForSale: (state) => state
         }
-      },
-      actions: {
-        setChipsForSale: (chips) => ({ type: SET_CHIPS_FOR_SALE, chips })
-      },
-      selectors: {
-        getChipsForSale: (state) => state
-      }
-    };
+      };
 
-    const singleModule = combineModules({
-      favoriteChips,
-      chipsForSale
+      const singleModule = combineModules({
+        favoriteChips,
+        chipsForSale
+      });
+
+      expect(singleModule.reducer).to.be.a('function');
+      expect(singleModule.reducer(undefined, { type: '__INIT__' })).to.deep.equal({
+        favoriteChips: 'unknown',
+        chipsForSale: [],
+      }, 'should combine reducers');
+
+      expect(singleModule.actions.setFavoriteChips('bbq')).to.deep.equal({
+        type: SET_FAVORITE_CHIPS,
+        newFav: 'bbq'
+      }, 'should combine actions');
+      expect(singleModule.actions.setChipsForSale(['salt & vinegar'])).to.deep.equal({
+        type: SET_CHIPS_FOR_SALE,
+        chips: ['salt & vinegar']
+      }, 'should combine actions');
+
+      const mockState = {
+        favoriteChips: 'bbq',
+        chipsForSale: ['salt & vinegar']
+      };
+      expect(singleModule.selectors.getFavoriteChips(mockState)).to.equal('bbq', 'should combine selectors');
+      expect(singleModule.selectors.getChipsForSale(mockState)).to.deep.equal(['salt & vinegar'], 'should combine selectors');
     });
 
-    expect(singleModule.reducer).to.be.a('function');
-    expect(singleModule.reducer(undefined, { type: '__INIT__' })).to.deep.equal({
-      favoriteChips: 'unknown',
-      chipsForSale: [],
-    }, 'should combine reducers');
+    it('should support reducers property', function () {
+      const chips = {
+        reducers: {
+          favorite: (state = 'bbq', action) => state,
+          forSale: (state = ['salt & vinegar'], action) => state,
+        },
+        actions: {},
+        selectors: {
+          getFavoriteChips: (state) => state.favorite,
+          getChipsForSale: (state) => state.forSale
+        },
+      };
+      const favoriteDrink = {
+        reducer: (state = 'coffee', action) => state,
+        actions: {},
+        selectors: {
+          getFavoriteDrink: (state) => state,
+        },
+      }
 
-    expect(singleModule.actions.setFavoriteChips('bbq')).to.deep.equal({
-      type: SET_FAVORITE_CHIPS,
-      newFav: 'bbq'
-    }, 'should combine actions');
-    expect(singleModule.actions.setChipsForSale(['salt & vinegar'])).to.deep.equal({
-      type: SET_CHIPS_FOR_SALE,
-      chips: ['salt & vinegar']
-    }, 'should combine actions');
-
-    const mockState = {
-      favoriteChips: 'bbq',
-      chipsForSale: ['salt & vinegar']
-    };
-    expect(singleModule.selectors.getFavoriteChips(mockState)).to.equal('bbq', 'should combine selectors');
-    expect(singleModule.selectors.getChipsForSale(mockState)).to.deep.equal(['salt & vinegar'], 'should combine selectors');
+      const singleModule = combineModules({ chips, favoriteDrink });
+      const state = singleModule.reducer(undefined, { type: '__INIT__' });
+      expect(singleModule.selectors.getFavoriteChips(state)).to.equal('bbq');
+      expect(singleModule.selectors.getChipsForSale(state)).to.deep.equal(['salt & vinegar']);
+      expect(singleModule.selectors.getFavoriteDrink(state)).to.equal('coffee');
+    });
   });
 
-  it('should support reducers property for compatability with classic module pattern', function () {
-    const chips = {
-      reducers: {
-        favorite: (state = 'bbq', action) => state,
-        forSale: (state = ['salt & vinegar'], action) => state,
-      },
-      actions: {},
-      selectors: {
-        getFavoriteChips: (state) => state.favorite,
-        getChipsForSale: (state) => state.forSale
-      },
-    };
-    const favoriteDrink = {
-      reducer: (state = 'coffee', action) => state,
-      actions: {},
-      selectors: {
-        getFavoriteDrink: (state) => state,
-      },
-    }
-
-    const singleModule = combineModules({ chips, favoriteDrink });
-    const state = singleModule.reducer(undefined, { type: '__INIT__' });
-    expect(singleModule.selectors.getFavoriteChips(state)).to.equal('bbq');
-    expect(singleModule.selectors.getChipsForSale(state)).to.deep.equal(['salt & vinegar']);
-    expect(singleModule.selectors.getFavoriteDrink(state)).to.equal('coffee');
+  describe('reducerToModule', function () {
+    const testReducer = (state, action) => 'hello';
+    const testModule = reducerToModule(testReducer);
+    const combinedModule = combineModules({ testModule });
+    expect(combinedModule.reducer(undefined, { type: '__INIT__' })).to.deep.equal({ testModule: 'hello' });
   });
 
   // it('should have a settableValueModule helper')

--- a/specs/src/modules.spec.js
+++ b/specs/src/modules.spec.js
@@ -5,41 +5,41 @@ describe('deeply nested modules', function () {
   const SET_FAVORITE_CHIPS = 'chips/SET_FAVORITE_CHIPS';
   const SET_CHIPS_FOR_SALE = 'chips/SET_CHIPS_FOR_SALE';
 
-  const favoriteChips = {
-    reducer: (state = 'unknown', action) => {
-      switch (action.type) {
-        case SET_FAVORITE_CHIPS:
-          return action.newFav;
-        default:
-          return state;
-      }
-    },
-    actions: {
-      setFavoriteChips: (newFav) => ({ type: SET_FAVORITE_CHIPS, newFav })
-    },
-    selectors: {
-      getFavoriteChips: (state) => state
-    }
-  }
-
-  const chipsForSale = {
-    reducer: (state = [], action) => {
-      switch (action.type) {
-        case SET_CHIPS_FOR_SALE:
-          return action.chips
-        default:
-          return state;
-      }
-    },
-    actions: {
-      setChipsForSale: (chips) => ({ type: SET_CHIPS_FOR_SALE, chips })
-    },
-    selectors: {
-      getChipsForSale: (state) => state
-    }
-  };
-
   it('should combine modules', function () {
+    const favoriteChips = {
+      reducer: (state = 'unknown', action) => {
+        switch (action.type) {
+          case SET_FAVORITE_CHIPS:
+            return action.newFav;
+          default:
+            return state;
+        }
+      },
+      actions: {
+        setFavoriteChips: (newFav) => ({ type: SET_FAVORITE_CHIPS, newFav })
+      },
+      selectors: {
+        getFavoriteChips: (state) => state
+      }
+    }
+
+    const chipsForSale = {
+      reducer: (state = [], action) => {
+        switch (action.type) {
+          case SET_CHIPS_FOR_SALE:
+            return action.chips
+          default:
+            return state;
+        }
+      },
+      actions: {
+        setChipsForSale: (chips) => ({ type: SET_CHIPS_FOR_SALE, chips })
+      },
+      selectors: {
+        getChipsForSale: (state) => state
+      }
+    };
+
     const singleModule = combineModules({
       favoriteChips,
       chipsForSale
@@ -68,7 +68,33 @@ describe('deeply nested modules', function () {
     expect(singleModule.selectors.getChipsForSale(mockState)).to.deep.equal(['salt & vinegar'], 'should combine selectors');
   });
 
+  it('should support reducers property for compatability with classic module pattern', function () {
+    const chips = {
+      reducers: {
+        favorite: (state = 'bbq', action) => state,
+        forSale: (state = ['salt & vinegar'], action) => state,
+      },
+      actions: {},
+      selectors: {
+        getFavoriteChips: (state) => state.favorite,
+        getChipsForSale: (state) => state.forSale
+      },
+    };
+    const favoriteDrink = {
+      reducer: (state = 'coffee', action) => state,
+      actions: {},
+      selectors: {
+        getFavoriteDrink: (state) => state,
+      },
+    }
+
+    const singleModule = combineModules({ chips, favoriteDrink });
+    const state = singleModule.reducer(undefined, { type: '__INIT__' });
+    expect(singleModule.selectors.getFavoriteChips(state)).to.equal('bbq');
+    expect(singleModule.selectors.getChipsForSale(state)).to.deep.equal(['salt & vinegar']);
+    expect(singleModule.selectors.getFavoriteDrink(state)).to.equal('coffee');
+  });
+
   // it('should have a settableValueModule helper')
   // it('should support array modules of some sort')
-  // it('should support reducers property for compatability with classic module pattern')
 });

--- a/specs/src/selectors.spec.js
+++ b/specs/src/selectors.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import combineSelectors from './../../src/selectors.js';
+import combineSelectors, { addGlobalSelectors } from './../../src/selectors.js';
 
 import consoleErrors from './../../src/consoleErrors.js';
 import itWithConsoleErrorsStub from './testHelpers/itWithConsoleErrorsStub.js';
@@ -15,170 +15,197 @@ const expectKeysToDeepEqual = (selectors, keys) => {
   expect(selectorKeys).to.deep.equal(keys);
 };
 
-describe('combineSelectors', function() {
+describe('selectors', function () {
+  describe('combineSelectors', function() {
 
-  before('stub console.error to suppress warnings', function() {
-    sinon.stub(console, 'error');
-  });
-  after('unstub console.error', function() {
-    console.error.restore();
-  });
+    before('stub console.error to suppress warnings', function() {
+      sinon.stub(console, 'error');
+    });
+    after('unstub console.error', function() {
+      console.error.restore();
+    });
 
-  it('should combine all reducer and global selectors as one object', function () {
-    const reducers = {
-      reducerOne:{selectorOne:f,selectorTwo:f},
-      reducerTwo:{selectorThree:f}
-    };
-    const selectors = combineSelectors(reducers, {globalselectorOne:fG});
+    itWithConsoleErrorsStub('should consoleErrors to check for dup selectors', function () {
+      combineSelectors({one:{one:f}});
+      expect(consoleErrors.duplicateName.callCount).to.equal(1);
+    });
 
-    expectKeysToDeepEqual(selectors, ['selectorOne', 'selectorTwo', 'selectorThree', 'globalselectorOne']);
-  });
-  it('should not require the globalSelectors paramater', function () {
-    const reducers = {
-      reducerOne:{selectorOne:f},
-      reducerTwo:{selectorTwo:f}
-    };
-    const selectors = combineSelectors(reducers);
+    itWithConsoleErrorsStub('should consoleErrors to check if the selector is a function', function () {
+      combineSelectors({one:{one:f}});
+      expect(consoleErrors.notFunction.callCount).to.equal(1);
+    });
 
-    expectKeysToDeepEqual(selectors, ['selectorOne', 'selectorTwo']);
-  });
+    it('should not add selectors that aren\'t functions', function () {
+      const selectors = combineSelectors({one:{two:f,three:''}});
+      expectKeysToDeepEqual(selectors, ['two']);
+    });
+    it('should not add global selectors that aren\'t functions', function () {
+      const selectors = combineSelectors({one:{two:f}}, {three:''});
+      expectKeysToDeepEqual(selectors, ['two']);
+    });
 
-  itWithConsoleErrorsStub('should consoleErrors to check for dup selectors', function () {
-    combineSelectors({one:{one:f}});
-    expect(consoleErrors.duplicateName.callCount).to.equal(1);
-  });
-  itWithConsoleErrorsStub('should consoleErrors to check for dup global selectors', function () {
-    combineSelectors({one:{one:f}}, {globalOne:fG});
-    expect(consoleErrors.duplicateName.callCount).to.equal(2);
-  });
+    itWithConsoleErrorsStub('should consoleErrors to check if selector has no args', function () {
+      combineSelectors({one:{one:f}});
+      expect(consoleErrors.noArgsDefined.callCount).to.equal(1);
+    });
 
-  itWithConsoleErrorsStub('should consoleErrors to check if the selector is a function', function () {
-    combineSelectors({one:{one:f}});
-    expect(consoleErrors.notFunction.callCount).to.equal(1);
-  });
-  itWithConsoleErrorsStub('should consoleErrors to check if the global selector is a function', function () {
-    combineSelectors({one:{one:f}}, {globalOne:fG});
-    expect(consoleErrors.notFunction.callCount).to.equal(2);
-  });
+    it('should not add selectors that have no args defined', function () {
+      const selectors = combineSelectors({one:{one:f,two:()=>{}}});
+      expectKeysToDeepEqual(selectors, ['one']);
+    });
+    it('should not add global selectors that have no args defined', function () {
+      const selectors = combineSelectors({one:{one:f}}, {two:()=>{}});
+      expectKeysToDeepEqual(selectors, ['one']);
+    });
 
-  it('should not add selectors that aren\'t functions', function () {
-    const selectors = combineSelectors({one:{two:f,three:''}});
-    expectKeysToDeepEqual(selectors, ['two']);
-  });
-  it('should not add global selectors that aren\'t functions', function () {
-    const selectors = combineSelectors({one:{two:f}}, {three:''});
-    expectKeysToDeepEqual(selectors, ['two']);
-  });
+    it('should call the correct selector functions', function () {
+      const oneSpy = sinon.spy(f);
+      const twoSpy = sinon.spy(f);
+      const threeSpy = sinon.spy(f);
+      const reducerConfig = {
+        one: {
+          one: oneSpy,
+          two: twoSpy,
+        },
+        two: {
+          three: threeSpy
+        }
+      };
 
-  itWithConsoleErrorsStub('should consoleErrors to check if selector has no args', function () {
-    combineSelectors({one:{one:f}});
-    expect(consoleErrors.noArgsDefined.callCount).to.equal(1);
-  });
-  itWithConsoleErrorsStub('should consoleErrors to check if global selector has no args', function () {
-    combineSelectors({one:{one:f}}, {globalOne:fG});
-    expect(consoleErrors.noArgsDefined.callCount).to.equal(2);
-  });
+      const selectors = combineSelectors(reducerConfig);
 
-  it('should not add selectors that have no args defined', function () {
-    const selectors = combineSelectors({one:{one:f,two:()=>{}}});
-    expectKeysToDeepEqual(selectors, ['one']);
-  });
-  it('should not add global selectors that have no args defined', function () {
-    const selectors = combineSelectors({one:{one:f}}, {two:()=>{}});
-    expectKeysToDeepEqual(selectors, ['one']);
-  });
+      const mockState = {};
 
-  it('should call the correct selector functions', function () {
-    const oneSpy = sinon.spy(f);
-    const twoSpy = sinon.spy(f);
-    const threeSpy = sinon.spy(f);
-    const globalOneSpy = sinon.spy(fG);
-    const reducerConfig = {
-      one: {
-        one: oneSpy,
-        two: twoSpy,
-      },
-      two: {
-        three: threeSpy
-      }
-    };
+      selectors.one(mockState);
+      expect(oneSpy.callCount).to.equal(1);
 
-    const selectors = combineSelectors(reducerConfig, {globalOne:globalOneSpy});
+      selectors.two(mockState);
+      expect(twoSpy.callCount).to.equal(1);
 
-    const mockState = {};
+      selectors.three(mockState);
+      expect(threeSpy.callCount).to.equal(1);
+    });
 
-    selectors.one(mockState);
-    expect(oneSpy.callCount).to.equal(1);
+    it('should pass the reducer\'s state (not entire state) as the first selector arg', function () {
+      const oneSpy = sinon.spy(f);
+      const twoSpy = sinon.spy(f);
+      const selectors = combineSelectors({one:{one:oneSpy},two:{two:twoSpy}});
 
-    selectors.two(mockState);
-    expect(twoSpy.callCount).to.equal(1);
+      const mockState = {
+        one: {
+          oneState: 'one'
+        },
+        two: {
+          twoState: 'two'
+        }
+      };
 
-    selectors.three(mockState);
-    expect(threeSpy.callCount).to.equal(1);
+      selectors.one(mockState);
+      expect(oneSpy.firstCall.args).to.deep.equal([mockState.one]);
 
-    selectors.globalOne();
-    expect(globalOneSpy.callCount).to.equal(1);
+      selectors.two(mockState);
+      expect(twoSpy.firstCall.args).to.deep.equal([mockState.two]);
+    });
+    it('should pass any additional selector args to selector', function () {
+      const oneSpy = sinon.spy(f);
+      const selectors = combineSelectors({one:{one:oneSpy}});
+
+      const mockState = {};
+
+      selectors.one(mockState, 'AddiTIONalArgONE', 'AdDITionALArgtwo');
+      expect(oneSpy.firstCall.args.slice(1)).to.deep.equal(['AddiTIONalArgONE', 'AdDITionALArgtwo']);
+    });
   });
 
-  it('should pass the reducer\'s state (not entire state) as the first selector arg', function () {
-    const oneSpy = sinon.spy(f);
-    const twoSpy = sinon.spy(f);
-    const selectors = combineSelectors({one:{one:oneSpy},two:{two:twoSpy}});
+  describe('addGlobalSelectors', function () {
+    it('should combine all reducer and global selectors as one object', function () {
+      const reducers = {
+        reducerOne:{selectorOne:f,selectorTwo:f},
+        reducerTwo:{selectorThree:f}
+      };
+      const selectors = addGlobalSelectors(combineSelectors(reducers), {globalselectorOne:fG});
 
-    const mockState = {
-      one: {
-        oneState: 'one'
-      },
-      two: {
-        twoState: 'two'
-      }
-    };
+      expectKeysToDeepEqual(selectors, ['selectorOne', 'selectorTwo', 'selectorThree', 'globalselectorOne']);
+    });
 
-    selectors.one(mockState);
-    expect(oneSpy.firstCall.args).to.deep.equal([mockState.one]);
+    itWithConsoleErrorsStub('should consoleErrors to check for dup global selectors', function () {
+      addGlobalSelectors(combineSelectors({one:{one:f}}), {globalOne:fG});
+      expect(consoleErrors.duplicateName.callCount).to.equal(2);
+    });
 
-    selectors.two(mockState);
-    expect(twoSpy.firstCall.args).to.deep.equal([mockState.two]);
-  });
-  it('should pass any additional selector args to selector', function () {
-    const oneSpy = sinon.spy(f);
-    const selectors = combineSelectors({one:{one:oneSpy}});
+    itWithConsoleErrorsStub('should consoleErrors to check if global selector has no args', function () {
+      addGlobalSelectors(combineSelectors({one:{one:f}}), {globalOne:fG});
+      expect(consoleErrors.noArgsDefined.callCount).to.equal(2);
+    });
 
-    const mockState = {};
+    itWithConsoleErrorsStub('should consoleErrors to check if the global selector is a function', function () {
+      addGlobalSelectors(combineSelectors({one:{one:f}}), {globalOne:fG});
+      expect(consoleErrors.notFunction.callCount).to.equal(2);
+    });
 
-    selectors.one(mockState, 'AddiTIONalArgONE', 'AdDITionALArgtwo');
-    expect(oneSpy.firstCall.args.slice(1)).to.deep.equal(['AddiTIONalArgONE', 'AdDITionALArgtwo']);
-  });
-  it('should pass the selectors object to global selectors', function () {
-    const globalTwoSpy = sinon.spy(fG);
-    const selectors = combineSelectors({one:{one:f}}, {two:globalTwoSpy});
+    it('should call the correct global selector functions', function () {
+      const oneSpy = sinon.spy(f);
+      const twoSpy = sinon.spy(f);
+      const threeSpy = sinon.spy(f);
+      const globalOneSpy = sinon.spy(fG);
+      const reducerConfig = {
+        one: {
+          one: oneSpy,
+          two: twoSpy,
+        },
+        two: {
+          three: threeSpy
+        }
+      };
 
-    selectors.two();
-    expect(globalTwoSpy.firstCall.args.length).to.equal(1);
-    expectKeysToDeepEqual(globalTwoSpy.firstCall.args[0], ['one', 'two']);
-  });
+      const selectors = addGlobalSelectors(combineSelectors(reducerConfig), {globalOne:globalOneSpy});
 
-  it('should pass any additional global selector args to global selector', function () {
-    const globalTwoSpy = sinon.spy(fG);
-    const selectors = combineSelectors({one:{one:f}}, {two:globalTwoSpy});
+      const mockState = {};
 
-    selectors.two('AddiTIONalArgONE', 'AdDITionALArgtwo');
-    expect(globalTwoSpy.firstCall.args.slice(1)).to.deep.equal(['AddiTIONalArgONE', 'AdDITionALArgtwo']);
-  });
+      selectors.one(mockState);
+      expect(oneSpy.callCount).to.equal(1);
 
-  it('should return values from reducer and global selectors', function () {
-    const one = oneState => 'oneResult';
-    const globalTwo = selectors => 'globalResult';
-    const selectors = combineSelectors({one:{one:one}}, {two:globalTwo});
+      selectors.two(mockState);
+      expect(twoSpy.callCount).to.equal(1);
 
-    const mockState = {
-      one: {}
-    };
+      selectors.three(mockState);
+      expect(threeSpy.callCount).to.equal(1);
 
-    const oneResult = selectors.one(mockState);
-    const globalTwoResult = selectors.two();
+      selectors.globalOne();
+      expect(globalOneSpy.callCount).to.equal(1);
+    });
 
-    expect(oneResult).to.equal('oneResult');
-    expect(globalTwoResult).to.equal('globalResult');
+    it('should pass the selectors object to global selectors', function () {
+      const globalTwoSpy = sinon.spy(fG);
+      const selectors = addGlobalSelectors(combineSelectors({one:{one:f}}), {two:globalTwoSpy});
+
+      selectors.two();
+      expect(globalTwoSpy.firstCall.args.length).to.equal(1);
+      expectKeysToDeepEqual(globalTwoSpy.firstCall.args[0], ['one', 'two']);
+    });
+
+    it('should pass any additional global selector args to global selector', function () {
+      const globalTwoSpy = sinon.spy(fG);
+      const selectors = addGlobalSelectors(combineSelectors({one:{one:f}}), {two:globalTwoSpy});
+
+      selectors.two('AddiTIONalArgONE', 'AdDITionALArgtwo');
+      expect(globalTwoSpy.firstCall.args.slice(1)).to.deep.equal(['AddiTIONalArgONE', 'AdDITionALArgtwo']);
+    });
+
+    it('should return values from reducer and global selectors', function () {
+      const one = oneState => 'oneResult';
+      const globalTwo = selectors => 'globalResult';
+      const selectors = addGlobalSelectors(combineSelectors({one:{one:one}}), {two:globalTwo});
+
+      const mockState = {
+        one: {}
+      };
+
+      const oneResult = selectors.one(mockState);
+      const globalTwoResult = selectors.two();
+
+      expect(oneResult).to.equal('oneResult');
+      expect(globalTwoResult).to.equal('globalResult');
+    });
   });
 });

--- a/specs/src/store.spec.js
+++ b/specs/src/store.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 // Import the default function and then import the rest seperately.
 // If you do import { } from '...', then they can't be stubbed.
 import createStore, { switchGlobalDefinitionsAndReduxConfig } from './../../src/store.js';
-
+import { combineModules } from '../../src/modules';
 import consoleErrors from './../../src/consoleErrors.js';
 
 const itWithConsoleErrorsSpy = function(should, fn) {
@@ -325,6 +325,33 @@ describe('createStore', function() {
 
     const { store } = createStore({chips, drinks});
     expect(store.getState()).to.deep.equal({chips:{}});
+  });
+
+  it('should support combined modules', function () {
+    const favoriteChip = {
+      reducer: (state = 'bbq', action) => state,
+      actions: {
+        clearFavoriteChip: () => ({type:'CLEAR_FAVORITE_CHIP'})
+      },
+      selectors: {}
+    };
+    const favoriteDrink = {
+      reducer: (state = 'mountain dew', action) => state,
+      actions: {
+        clearFavoriteDrink: () => ({type:'CLEAR_FAVORITE_DRINK'})
+      },
+      selectors: {}
+    };
+
+    const { store } = createStore({
+      refreshments: combineModules({ favoriteChip, favoriteDrink })
+    });
+    expect(store.getState()).to.deep.equal({
+      refreshments: {
+        favoriteChip: 'bbq',
+        favoriteDrink: 'mountain dew',
+      }
+    });
   });
 
   it('should include redux-freeze when not in production');

--- a/src/actions.js
+++ b/src/actions.js
@@ -14,7 +14,7 @@ import consoleErrors from './consoleErrors.js';
  *                                     global actions to trigger reducer actions.
  * @return {Object}                    All actions combined into one object.
  */
-const combineActions = (reducers, globalActions = {}) => {
+const combineActions = (reducers) => {
   let combinedActions = {};
 
   // Combine all reducers' actions into one object.
@@ -36,6 +36,10 @@ const combineActions = (reducers, globalActions = {}) => {
     });
   });
 
+  return combinedActions
+};
+
+const addGlobalActions = (combinedActions, globalActions) => {
   // If there's any global actions, then do the same thing as above.
   Object.keys(globalActions).forEach(actionName => {
     const globalAction = globalActions[actionName];
@@ -58,7 +62,7 @@ const combineActions = (reducers, globalActions = {}) => {
   });
 
   return combinedActions;
-};
+}
 
 /**
  * A function useful to components so they can pick what actions they use so
@@ -85,4 +89,4 @@ const pickActions = (actions, ...actionNames) => {
 };
 
 export default combineActions;
-export { pickActions };
+export { pickActions, addGlobalActions };

--- a/src/consoleErrors.js
+++ b/src/consoleErrors.js
@@ -80,12 +80,6 @@ consoleErrors.invalidReducerConfig = (reducerName, reducerConfig) => {
   }
 
   let hasReducer = false;
-  // if (reducerConfig.reducer) {
-    // if (typeof reducerConfig.reducer === 'function') {
-    //   warning(false, `The "reducer" value of the ${reducerName} config should be a function, not ${typeof reducerConfig.reducer}.`);
-    //   return true;
-    // }
-  // }
 
   if (reducerConfig.reducers) {
     if (typeof reducerConfig.reducers !== 'object') {

--- a/src/consoleErrors.js
+++ b/src/consoleErrors.js
@@ -65,7 +65,7 @@ consoleErrors.noArgsDefined = (name, funcName, func, argDesc) => {
  * @return {bool}                 True if it's missing a key or the key value is invalid, else false.
  */
 consoleErrors.invalidReducerConfig = (reducerName, reducerConfig) => {
-  const requiredKeys = ['reducers', 'actions', 'selectors'];
+  const requiredKeys = ['actions', 'selectors'];
   for(let i = 0; i < requiredKeys.length; i++) {
     const key = requiredKeys[i];
 
@@ -77,6 +77,33 @@ consoleErrors.invalidReducerConfig = (reducerName, reducerConfig) => {
       warning(false, `The "${key}" value of the ${reducerName} config should be an object, not ${typeof reducerConfig[key]}.`);
       return true;
     }
+  }
+
+  let hasReducer = false;
+  // if (reducerConfig.reducer) {
+    // if (typeof reducerConfig.reducer === 'function') {
+    //   warning(false, `The "reducer" value of the ${reducerName} config should be a function, not ${typeof reducerConfig.reducer}.`);
+    //   return true;
+    // }
+  // }
+
+  if (reducerConfig.reducers) {
+    if (typeof reducerConfig.reducers !== 'object') {
+      warning(false, `The "reducers" value of the ${reducerName} config should be an object, not ${typeof reducerConfig.reducers}.`);
+      return true;
+    }
+    hasReducer = true;
+  } else if (reducerConfig.reducer) {
+    if (typeof reducerConfig.reducer !== 'function') {
+      warning(false, `The "reducer" value of the ${reducerName} config should be a function, not ${typeof reducerConfig.reducer}.`);
+      return true;
+    }
+    hasReducer = true;
+  }
+
+  if (!hasReducer) {
+    warning(false, `The ${reducerName} config should have either a "reducer" or "reducers" property defined.`);
+    return true;
   }
 
   return false;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import createStore from './store.js';
 import { combineModules } from './modules';
+import { settableValue } from './moduleCreators';
 
 // Instead of:
 //    "export default createStore"
@@ -9,3 +10,4 @@ import { combineModules } from './modules';
 //    require('modular-redux-thunk').default
 module.exports = createStore;
 module.exports.combineModules = combineModules;
+module.exports.settableValue = settableValue;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import createStore from './store.js';
+import { combineModules, reducerToModule } from './modules';
 
 // Instead of:
 //    "export default createStore"
@@ -7,3 +8,5 @@ import createStore from './store.js';
 // But we don't to require users to do:
 //    require('modular-redux-thunk').default
 module.exports = createStore;
+module.exports.combineModules = combineModules;
+module.exports.reducerToModule = reducerToModule;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import createStore from './store.js';
-import { combineModules, reducerToModule } from './modules';
+import { combineModules } from './modules';
 
 // Instead of:
 //    "export default createStore"
@@ -9,4 +9,3 @@ import { combineModules, reducerToModule } from './modules';
 //    require('modular-redux-thunk').default
 module.exports = createStore;
 module.exports.combineModules = combineModules;
-module.exports.reducerToModule = reducerToModule;

--- a/src/moduleCreators.js
+++ b/src/moduleCreators.js
@@ -1,0 +1,20 @@
+export function settableValue(initialValue, selectorName, actionName, actionType = actionName) {
+  return {
+    reducer: (state = initialValue, action) => {
+      if (action.type === actionType) {
+        return action.payload;
+      } else {
+        return state;
+      }
+    },
+    actions: {
+      [actionName]: (payload) => ({
+        type: actionType,
+        payload
+      })
+    },
+    selectors: {
+      [selectorName]: state => state
+    }
+  }
+}

--- a/src/modules.js
+++ b/src/modules.js
@@ -1,0 +1,27 @@
+import { combineReducers } from 'redux';
+import combineActions from './actions';
+import combineSelectors from './selectors';
+
+const mapModules = (modules, fn) =>
+  Object.keys(modules).reduce((obj, k) =>
+    Object.assign(obj, {[k]: fn(modules[k])})
+  , {});
+
+export function combineModules(modules) {
+  const reducer = combineReducers(
+    mapModules(modules, m => m.reducer)
+  );
+  const actions = combineActions(
+    mapModules(modules, m => m.actions)
+  );
+  const selectors = combineSelectors(
+    mapModules(modules, m => m.selectors)
+  );
+
+  return {
+    reducer,
+    actions,
+    selectors,
+    _modulesCombined: true
+  };
+}

--- a/src/modules.js
+++ b/src/modules.js
@@ -7,9 +7,14 @@ const mapModules = (modules, fn) =>
     Object.assign(obj, {[k]: fn(modules[k])})
   , {});
 
+const getReducerFromModule = (module) =>
+  module.reducers
+    ? combineReducers(module.reducers)
+    : module.reducer;
+
 export function combineModules(modules) {
   const reducer = combineReducers(
-    mapModules(modules, m => m.reducer)
+    mapModules(modules, getReducerFromModule)
   );
   const actions = combineActions(
     mapModules(modules, m => m.actions)

--- a/src/modules.js
+++ b/src/modules.js
@@ -35,3 +35,11 @@ export function combineModules(modules) {
     selectors,
   };
 }
+
+export function reducerToModule(reducer) {
+  return {
+    reducer,
+    actions: {},
+    selectors: {}
+  };
+}

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -54,6 +54,10 @@ const combineSelectors = (reducers, globalSelectors = {}) => {
     });
   });
 
+  return combinedSelectors;
+};
+
+export const addGlobalSelectors = (combinedSelectors, globalSelectors) => {
   // If there's any global selectors, then do the same thing as above.
   Object.keys(globalSelectors).map(selectorName => {
     const selector = globalSelectors[selectorName];

--- a/src/store.js
+++ b/src/store.js
@@ -9,7 +9,7 @@ import thunk from 'redux-thunk';
 import combineSelectors, { addGlobalSelectors } from './selectors.js';
 import combineActions, { pickActions as pickActionsWrapper, addGlobalActions } from './actions.js';
 
-import { combineModules } from './modules';
+import { combineModules, reducerToModule } from './modules';
 
 import consoleErrors from './consoleErrors.js';
 
@@ -62,7 +62,14 @@ const createStore = (modularReduxDefinition, globalDefinitions=null, reduxConfig
   const { globalSelectors = {}, globalActions = {} } = (globalDefinitions || {});
   const { reducers = {}, middleware = [], enhancers = [] } = (reduxConfig || {});
 
-  const rootModule = combineModules(modularReduxDefinition);
+  const reducerModules = Object.keys(reducers).reduce((obj, k) =>
+    Object.assign(obj, { [k]: reducerToModule(reducers[k]) })
+  , {});
+
+  const rootModule = combineModules(Object.assign({},
+    modularReduxDefinition,
+    reducerModules
+  ));
 
   // Combine all reducer's selectors and any global selectors into one.
   const selectors = addGlobalSelectors(rootModule.selectors, globalSelectors);


### PR DESCRIPTION
Added a few major refactors:
- Renamed "reducer" to "module" in many places, except where the term applies to a reducer function specifically.
- Added a new exported `combineModules` function - this allows you to create more fine-grained modules and compose them together. `createStore` is now largely based on this function.
- Added a new `reducer` property to modules - now you can specify a single reducer for a module and have it control the module's entire state.
